### PR TITLE
Shellcode and Pathing Updates

### DIFF
--- a/AsaApiLoader/AsaApiLoader.cpp
+++ b/AsaApiLoader/AsaApiLoader.cpp
@@ -35,8 +35,8 @@ int main() {
     dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     SetConsoleMode(hOut, dwMode);
 
-    fs::path server = loader::findExe();
-    fs::path dll = loader::findDll();
+    fs::path server = loader::find_server();
+    fs::path dll = loader::find_dll();
 
     if (!std::filesystem::exists(server))
         return reject(nullptr, "Server Missing!");

--- a/AsaApiLoader/Public/Loader.ixx
+++ b/AsaApiLoader/Public/Loader.ixx
@@ -1,6 +1,7 @@
 module;
 #include <filesystem>
 #include <Windows.h>
+#include <iostream>
 export module Loader;
 
 export import :Text;
@@ -9,17 +10,24 @@ export import :Inject;
 
 export namespace loader
 {
-	[[nodiscard]] auto findApiDirectory() -> std::filesystem::path
+	[[nodiscard]] auto get_exe_path() -> std::filesystem::path
 	{
-		return std::filesystem::current_path().append(TEXT(R"(ArkApi)"));
-	}
-	[[nodiscard]] auto findDll() -> std::filesystem::path
-	{
-		return findApiDirectory().append(TEXT(R"(AsaApi.dll)"));
+		TCHAR buffer[MAX_PATH];
+		GetModuleFileName(NULL, buffer, sizeof(buffer));
+		return std::filesystem::path(buffer).parent_path();
 	}
 
-	[[nodiscard]] auto findExe() -> std::filesystem::path
+	[[nodiscard]] auto find_api_directory() -> std::filesystem::path
 	{
-		return std::filesystem::current_path().append(TEXT(R"(ArkAscendedServer.exe)"));
+		return get_exe_path()/(TEXT(R"(ArkApi)"));
+	}
+	[[nodiscard]] auto find_dll() -> std::filesystem::path
+	{
+		return find_api_directory()/(TEXT(R"(AsaApi.dll)"));
+	}
+
+	[[nodiscard]] auto find_server() -> std::filesystem::path
+	{
+		return get_exe_path()/(TEXT(R"(ArkAscendedServer.exe)"));
 	}
 }


### PR DESCRIPTION
This update adjusts the shellcode to enable better error handling, including pulling the thread's LastErrorCode as well as the stage that the thread failed in.

The shellcode is also updated to use LoadLibraryEx, which will allow future security features such as `LOAD_LIBRARY_REQUIRE_SIGNED_TARGET` in the flags parameter.

Additionally, this changes the Loader to use the executable path instead of the working path. This removes the requirement that whatever execution environment is starting the loader needed to have the working path set.